### PR TITLE
feat: bump plugin-cloud and payload

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,14 +18,14 @@
     "lint:fix": "eslint --fix --ext .ts,.tsx src"
   },
   "dependencies": {
-    "@payloadcms/plugin-cloud": "^1.0.0",
+    "@payloadcms/plugin-cloud": "^2.0.0",
     "@payloadcms/plugin-form-builder": "^1.0.13",
     "@payloadcms/plugin-nested-docs": "^1.0.4",
     "@payloadcms/plugin-redirects": "^1.0.0",
     "@payloadcms/plugin-seo": "^1.0.10",
     "dotenv": "^8.2.0",
     "express": "^4.17.1",
-    "payload": "^1.7.2"
+    "payload": "^1.8.2"
   },
   "devDependencies": {
     "@payloadcms/eslint-config": "^0.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1504,10 +1504,10 @@
   resolved "https://registry.yarnpkg.com/@payloadcms/eslint-config/-/eslint-config-0.0.1.tgz#4324702ddef6c773b3f3033795a13e6b50c95a92"
   integrity sha512-Il59+0C4E/bI6uM2hont3I+oABWkJZbfbItubje5SGMrXkymUq8jT/UZRk0eCt918bB7gihxDXx8guFnR/aNIw==
 
-"@payloadcms/plugin-cloud@^1.0.0":
-  version "1.0.0"
-  resolved "https://registry.npmjs.org/@payloadcms/plugin-cloud/-/plugin-cloud-1.0.0.tgz#76d812d497a7141ba36a9210f054c5fb141ac42d"
-  integrity sha512-iOCHH25Mhs/K4vcR0J6abT/aKapPxsMOkBvd/Tk+ARdhd7J9GEkzMnfJguK9SDOutJLLDk2XGto47aXPT2oKBg==
+"@payloadcms/plugin-cloud@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.npmjs.org/@payloadcms/plugin-cloud/-/plugin-cloud-2.0.0.tgz#36a468e2effb1ff722078d7a7cd5f7cdad585941"
+  integrity sha512-fSBi9M3ZodoFX7K7MARSy9bS4rfXqqlRith0t/5IJ23exiXVKUBxgBSjEosJIFiu9gMwWsOK25RKKC8fQrbKmQ==
   dependencies:
     "@aws-sdk/client-cognito-identity" "^3.289.0"
     "@aws-sdk/client-s3" "^3.142.0"
@@ -5801,10 +5801,10 @@ pause@0.0.1:
   resolved "https://registry.yarnpkg.com/pause/-/pause-0.0.1.tgz#1d408b3fdb76923b9543d96fb4c9dfd535d9cb5d"
   integrity sha512-KG8UEiEVkR3wGEb4m5yZkVCzigAD+cVEJck2CzYZO37ZGJfctvVptVO192MwrtPhzONn6go8ylnOdMhKqi4nfg==
 
-payload@^1.7.2:
-  version "1.7.2"
-  resolved "https://registry.yarnpkg.com/payload/-/payload-1.7.2.tgz#22aeb42871b1f09279382db9731724c697f44460"
-  integrity sha512-577DgrstocvKlnBo5ZgXEoH65qtoxP7HozgpgsFqAAgxCxudJ1zlnAAvce5usFxYdkOg6Yj1ezkq2ttLJeZbxA==
+payload@^1.8.2:
+  version "1.8.2"
+  resolved "https://registry.npmjs.org/payload/-/payload-1.8.2.tgz#94edff09f1580aa6dc28b41210244229303e1435"
+  integrity sha512-Bk7nDGdaQAhMIX7J9S+FkbLoZ+PNVrmwAg84RAj9Q7JyBeHHmJyDSTaGVenzXjWpch5bbMEd9nNdezpSalmZeg==
   dependencies:
     "@date-io/date-fns" "^2.16.0"
     "@dnd-kit/core" "^6.0.7"
@@ -5904,7 +5904,7 @@ payload@^1.7.2:
     slate-react "^0.92.0"
     style-loader "^2.0.0"
     swc-loader "^0.2.3"
-    swc-minify-webpack-plugin "^1.0.1"
+    swc-minify-webpack-plugin "^2.1.0"
     terser-webpack-plugin "^5.3.6"
     ts-essentials "^7.0.3"
     url-loader "^4.1.1"
@@ -7596,10 +7596,10 @@ swc-loader@^0.2.3:
   resolved "https://registry.yarnpkg.com/swc-loader/-/swc-loader-0.2.3.tgz#6792f1c2e4c9ae9bf9b933b3e010210e270c186d"
   integrity sha512-D1p6XXURfSPleZZA/Lipb3A8pZ17fP4NObZvFCDjK/OKljroqDpPmsBdTraWhVBqUNpcWBQY1imWdoPScRlQ7A==
 
-swc-minify-webpack-plugin@^1.0.1:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/swc-minify-webpack-plugin/-/swc-minify-webpack-plugin-1.1.2.tgz#4b8c97b005ab2bf1e993f9a0d38903227cc198d8"
-  integrity sha512-4GP6FlHsGZ8fA23OfEwSrGHOsAgYed/mCWlQmom7ocdd2AhHJsGNkHXsctjsKVfREIPcOdjZmim4ljkigz3EMw==
+swc-minify-webpack-plugin@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.npmjs.org/swc-minify-webpack-plugin/-/swc-minify-webpack-plugin-2.1.0.tgz#35f975595d2e090064f34cb57f4ac4fd98a67eaa"
+  integrity sha512-v4B+Wcr84q58w2uALmjdTmOKyoF0pWY1xoGzy5vMibuQXQ0dHXlTmhodfu1NCiOISkqMf3T10nFmFQutBLw/vA==
 
 tabbable@^5.3.3:
   version "5.3.3"


### PR DESCRIPTION
Upgrade to latest payload and latest [plugin-cloud](https://www.npmjs.com/package/@payloadcms/plugin-cloud) 2.0, which includes email capability.